### PR TITLE
Run download tests in parallel

### DIFF
--- a/download/download_test.go
+++ b/download/download_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestStartStop(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 
@@ -61,6 +63,8 @@ func TestStartStop(t *testing.T) {
 }
 
 func TestStartStopWithBundlePersistence(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 
@@ -117,6 +121,8 @@ func TestStartStopWithBundlePersistence(t *testing.T) {
 }
 
 func TestStopWithMultipleCalls(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 
@@ -157,6 +163,8 @@ func TestStopWithMultipleCalls(t *testing.T) {
 }
 
 func TestStartStopWithLazyLoadingMode(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 
@@ -198,6 +206,8 @@ func TestStartStopWithLazyLoadingMode(t *testing.T) {
 }
 
 func TestStartStopWithDeltaBundleMode(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	updates := make(chan *Update)
@@ -233,6 +243,8 @@ func TestStartStopWithDeltaBundleMode(t *testing.T) {
 }
 
 func TestStartStopWithLongPollNotSupported(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	config := Config{}
@@ -263,6 +275,8 @@ func TestStartStopWithLongPollNotSupported(t *testing.T) {
 }
 
 func TestStartStopWithLongPollSupportedByServer(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	config := Config{}
@@ -299,6 +313,8 @@ func TestStartStopWithLongPollSupportedByServer(t *testing.T) {
 }
 
 func TestStartStopWithLongPollSupported(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	config := Config{}
@@ -326,6 +342,8 @@ func TestStartStopWithLongPollSupported(t *testing.T) {
 }
 
 func TestStartStopWithLongPollWithLongTimeout(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	config := Config{}
@@ -361,6 +379,7 @@ func TestStartStopWithLongPollWithLongTimeout(t *testing.T) {
 }
 
 func TestEtagCachingLifecycle(t *testing.T) {
+	t.Parallel()
 
 	ctx := context.Background()
 	fixture := newTestFixture(t)
@@ -455,6 +474,7 @@ func TestEtagCachingLifecycle(t *testing.T) {
 }
 
 func TestOneShotWithBundleEtag(t *testing.T) {
+	t.Parallel()
 
 	ctx := context.Background()
 	fixture := newTestFixture(t)
@@ -489,6 +509,7 @@ func TestOneShotWithBundleEtag(t *testing.T) {
 }
 
 func TestFailureAuthn(t *testing.T) {
+	t.Parallel()
 
 	ctx := context.Background()
 	fixture := newTestFixture(t)
@@ -504,6 +525,7 @@ func TestFailureAuthn(t *testing.T) {
 }
 
 func TestFailureNotFound(t *testing.T) {
+	t.Parallel()
 
 	ctx := context.Background()
 	fixture := newTestFixture(t)
@@ -519,6 +541,7 @@ func TestFailureNotFound(t *testing.T) {
 }
 
 func TestFailureUnexpected(t *testing.T) {
+	t.Parallel()
 
 	ctx := context.Background()
 	fixture := newTestFixture(t)
@@ -541,6 +564,8 @@ func TestFailureUnexpected(t *testing.T) {
 }
 
 func TestEtagInResponse(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 	fixture.server.etagInResponse = true
@@ -583,6 +608,7 @@ func TestEtagInResponse(t *testing.T) {
 }
 
 func TestTriggerManual(t *testing.T) {
+	t.Parallel()
 
 	ctx := context.Background()
 	fixture := newTestFixture(t)
@@ -630,6 +656,7 @@ func TestTriggerManual(t *testing.T) {
 }
 
 func TestTriggerManualWithTimeout(t *testing.T) {
+	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -677,6 +704,7 @@ func TestTriggerManualWithTimeout(t *testing.T) {
 }
 
 func TestDownloadLongPollNotModifiedOn304(t *testing.T) {
+	t.Parallel()
 
 	ctx := context.Background()
 	config := Config{}
@@ -705,6 +733,8 @@ func TestDownloadLongPollNotModifiedOn304(t *testing.T) {
 }
 
 func TestOneShotLongPollingSwitch(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	config := Config{}
 	timeout := int64(3) // this will result in the test server sleeping for 3 seconds
@@ -737,6 +767,8 @@ func TestOneShotLongPollingSwitch(t *testing.T) {
 }
 
 func TestOneShotNotLongPollingSwitch(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	config := Config{}
 	timeout := int64(3)
@@ -770,6 +802,8 @@ func TestOneShotNotLongPollingSwitch(t *testing.T) {
 }
 
 func TestWarnOnNonBundleContentType(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 	fixture.server.bundles["not-a-bundle"] = bundle.Bundle{}

--- a/download/oci_download_test.go
+++ b/download/oci_download_test.go
@@ -19,7 +19,6 @@ import (
 func TestOCIStartStop(t *testing.T) {
 	ctx := context.Background()
 	fixture := newTestFixture(t)
-	fixture.server.expAuth = "" // test on public registry
 	fixture.server.expEtag = "sha256:c5834dbce332cabe6ae68a364de171a50bf5b08024c27d7c08cc72878b4df7ff"
 
 	updates := make(chan *Update)
@@ -162,6 +161,10 @@ func TestOCIEtag(t *testing.T) {
 // TestOCIPublicRegistryAuth tests the registry `token` auth
 // that is implemented by public registries (more details are
 // in the doc comment of withPublicRegistryAuth).
+//
+// Other tests that don't explicitly set an authentication method
+// implicitly test no authentication - this is different from
+// the mechanism used by public registries.
 func TestOCIPublicRegistryAuth(t *testing.T) {
 	fixture := newTestFixture(t, withPublicRegistryAuth())
 

--- a/download/oci_download_test.go
+++ b/download/oci_download_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestOCIStartStop(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 	fixture.server.expEtag = "sha256:c5834dbce332cabe6ae68a364de171a50bf5b08024c27d7c08cc72878b4df7ff"
@@ -28,7 +30,7 @@ func TestOCIStartStop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", "/tmp/opa/").WithCallback(func(_ context.Context, u Update) {
+	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", t.TempDir()).WithCallback(func(_ context.Context, u Update) {
 		updates <- &u
 	})
 
@@ -51,6 +53,8 @@ func TestOCIStartStop(t *testing.T) {
 }
 
 func TestOCIBearerAuthPlugin(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 	plainToken := "secret"
@@ -80,7 +84,7 @@ func TestOCIBearerAuthPlugin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", "/tmp/oci")
+	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", t.TempDir())
 
 	if err := d.oneShot(ctx); err != nil {
 		t.Fatal(err)
@@ -88,12 +92,14 @@ func TestOCIBearerAuthPlugin(t *testing.T) {
 }
 
 func TestOCIFailureAuthn(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	fixture := newTestFixture(t)
 	fixture.server.expAuth = "Bearer badsecret"
 	defer fixture.server.stop()
 
-	d := NewOCI(Config{}, fixture.client, "ghcr.io/org/repo:latest", "/tmp/oci")
+	d := NewOCI(Config{}, fixture.client, "ghcr.io/org/repo:latest", t.TempDir())
 
 	err := d.oneShot(ctx)
 	if err == nil {
@@ -105,6 +111,8 @@ func TestOCIFailureAuthn(t *testing.T) {
 }
 
 func TestOCIEtag(t *testing.T) {
+	t.Parallel()
+
 	fixture := newTestFixture(t)
 	token := base64.StdEncoding.EncodeToString([]byte("secret")) // token should be base64 encoded
 	fixture.server.expAuth = fmt.Sprintf("Bearer %s", token)     // test on private repository
@@ -133,7 +141,7 @@ func TestOCIEtag(t *testing.T) {
 	}
 
 	firstResponse := Update{ETag: ""}
-	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", "/tmp/oci").WithCallback(func(_ context.Context, u Update) {
+	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", t.TempDir()).WithCallback(func(_ context.Context, u Update) {
 		if firstResponse.ETag == "" {
 			firstResponse = u
 			return
@@ -166,6 +174,8 @@ func TestOCIEtag(t *testing.T) {
 // implicitly test no authentication - this is different from
 // the mechanism used by public registries.
 func TestOCIPublicRegistryAuth(t *testing.T) {
+	t.Parallel()
+
 	fixture := newTestFixture(t, withPublicRegistryAuth())
 
 	restConfig := []byte(fmt.Sprintf(`{
@@ -187,6 +197,8 @@ func TestOCIPublicRegistryAuth(t *testing.T) {
 }
 
 func TestOCICustomAuthPlugin(t *testing.T) {
+	t.Parallel()
+
 	fixture := newTestFixture(t)
 	defer fixture.server.stop()
 
@@ -215,7 +227,7 @@ func TestOCICustomAuthPlugin(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", tmpDir)
+	d := NewOCI(config, fixture.client, "ghcr.io/org/repo:latest", t.TempDir())
 
 	if err := d.oneShot(context.Background()); err != nil {
 		t.Fatal(err)

--- a/download/testharness.go
+++ b/download/testharness.go
@@ -94,12 +94,12 @@ func withPublicRegistryAuth() fixtureOpt {
 				return fmt.Errorf("no authorization header: %w", errUnauthorized)
 			}
 
-			bearerToken, found := strings.CutPrefix(authHeader, "Bearer ")
-			if !found {
+			if !strings.HasPrefix(authHeader, "Bearer ") {
 				w.Header().Set("WWW-Authenticate", wwwAuthenticate)
 				return fmt.Errorf("expects bearer scheme: %w", errUnauthorized)
 			}
 
+			bearerToken := strings.TrimPrefix(authHeader, "Bearer ")
 			if bearerToken != token {
 				w.Header().Set("WWW-Authenticate", wwwAuthenticate)
 				return fmt.Errorf("token %q doesn't match %q: %w", bearerToken, token, errUnauthorized)

--- a/download/testharness.go
+++ b/download/testharness.go
@@ -39,15 +39,7 @@ func newTestFixture(t *testing.T, opts ...fixtureOpt) testFixture {
 	ts := newTestServer(t)
 	ts.start()
 
-	restConfig := []byte(fmt.Sprintf(`{
-		"url": %q,
-		"credentials": {
-			"bearer": {
-				"scheme": "Bearer",
-				"token": "secret"
-			}
-		}
-	}`, ts.server.URL))
+	restConfig := []byte(fmt.Sprintf(`{"url": %q}`, ts.server.URL))
 
 	client, err := rest.New(restConfig, map[string]*keys.Config{})
 	if err != nil {
@@ -188,8 +180,7 @@ type testServer struct {
 
 func newTestServer(t *testing.T) *testServer {
 	return &testServer{
-		t:       t,
-		expAuth: "Bearer secret",
+		t: t,
 		bundles: map[string]bundle.Bundle{
 			"test/bundle1": {
 				Manifest: bundle.Manifest{

--- a/download/testharness.go
+++ b/download/testharness.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,8 @@ import (
 	"github.com/open-policy-agent/opa/plugins/rest"
 )
 
+var errUnauthorized = errors.New("401 Unauthorized")
+
 type testFixture struct {
 	d                         *Downloader
 	client                    rest.Client
@@ -30,32 +33,119 @@ type testFixture struct {
 	etags                     map[string]string
 }
 
-func newTestFixture(t *testing.T) testFixture {
+func newTestFixture(t *testing.T, opts ...fixtureOpt) testFixture {
 	t.Helper()
 
 	ts := newTestServer(t)
 	ts.start()
 
 	restConfig := []byte(fmt.Sprintf(`{
-			"url": %q,
-			"credentials": {
-				"bearer": {
-					"scheme": "Bearer",
-					"token": "secret"
-				}
+		"url": %q,
+		"credentials": {
+			"bearer": {
+				"scheme": "Bearer",
+				"token": "secret"
 			}
-		}`, ts.server.URL))
+		}
+	}`, ts.server.URL))
 
-	tc, err := rest.New(restConfig, map[string]*keys.Config{})
+	client, err := rest.New(restConfig, map[string]*keys.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return testFixture{
-		client:  tc,
-		server:  ts,
-		updates: []Update{},
-		etags:   make(map[string]string),
+	fixture := testFixture{
+		server: ts,
+		client: client,
+		etags:  make(map[string]string),
+	}
+
+	for i, opt := range opts {
+		if err := opt(&fixture); err != nil {
+			t.Fatalf("Failed applying option #%d: %s", i, err)
+		}
+	}
+
+	return fixture
+}
+
+type fixtureOpt func(*testFixture) error
+
+// withPublicRegistryAuth sets up a token auth flow according to
+// the spec https://docs.docker.com/registry/spec/auth/token/.
+//
+// This authentication method is implemented by public
+// repositories of Github Container Registry, Docker Hub and
+// AWS ECR (and likely others) and corresponds with the auth
+// method `token` of the github.com/distribution/distribution
+// registry project.
+// See https://docs.docker.com/registry/configuration/#token.
+//
+// The token issuing and validation differs between providers
+// and we only use a minimal version for testing.
+func withPublicRegistryAuth() fixtureOpt {
+	const token = "some-test-token"
+	tokenServer := httptest.NewServer(tokenHandler(token))
+
+	const wwwAuthenticateFmt = "Bearer realm=%q service=%q scope=%q"
+	tokenServiceURL := tokenServer.URL + "/token"
+	wwwAuthenticate := fmt.Sprintf(wwwAuthenticateFmt,
+		tokenServiceURL,
+		"testRegistry.io",
+		"[pull]")
+
+	return func(tf *testFixture) error {
+		tf.server.customAuth = func(w http.ResponseWriter, r *http.Request) error {
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				w.Header().Set("WWW-Authenticate", wwwAuthenticate)
+				return fmt.Errorf("no authorization header: %w", errUnauthorized)
+			}
+
+			bearerToken, found := strings.CutPrefix(authHeader, "Bearer ")
+			if !found {
+				w.Header().Set("WWW-Authenticate", wwwAuthenticate)
+				return fmt.Errorf("expects bearer scheme: %w", errUnauthorized)
+			}
+
+			if bearerToken != token {
+				w.Header().Set("WWW-Authenticate", wwwAuthenticate)
+				return fmt.Errorf("token %q doesn't match %q: %w", bearerToken, token, errUnauthorized)
+			}
+
+			return nil
+		}
+
+		return nil
+	}
+}
+
+// tokenHandler returns an http.Handler that responds with the
+// specified token to GET /token requests.
+func tokenHandler(token string) http.HandlerFunc {
+	tokenResponse := struct {
+		Token string `json:"token"`
+	}{
+		Token: token,
+	}
+
+	responseBody, err := json.Marshal(tokenResponse)
+	if err != nil {
+		panic("failed to marshal token response: " + err.Error())
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		if r.URL.Path != "/token" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.Write(responseBody)
 	}
 }
 
@@ -86,6 +176,7 @@ func (t *testFixture) oneShot(ctx context.Context, u Update) {
 
 type testServer struct {
 	t              *testing.T
+	customAuth     func(http.ResponseWriter, *http.Request) error
 	expCode        int
 	expEtag        string
 	expAuth        string
@@ -157,7 +248,18 @@ func (t *testServer) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if t.expAuth != "" {
+	if t.customAuth != nil {
+		if err := t.customAuth(w, r); err != nil {
+			t.t.Logf("Failed authorization: %s", err)
+			if errors.Is(err, errUnauthorized) {
+				w.WriteHeader(401)
+				return
+			}
+
+			w.WriteHeader(500)
+			return
+		}
+	} else if t.expAuth != "" {
 		if r.Header.Get("Authorization") != t.expAuth {
 			w.WriteHeader(401)
 			return


### PR DESCRIPTION
### Why the changes in this PR are needed?

Tests in the `download` package are isolated under the `slow` build tag and take around 32s to run.

### What are the changes in this PR?

This PR marks all tests in the `download` package as parallelizable. This can significantly reduce test time (to ~5.5s with `-parallize=8` and 8 CPUs on my machine).

### Notes to assist PR review:

All tests are isolated from each other and no test has failed after numerous test runs. The change from `/tmp/oci` to `t.TempDir()` was the only change necessary,
